### PR TITLE
add detectionLabel and objectLabel template variables

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4803,6 +4803,10 @@ export default class AdvancedNotifierPlugin
 
     const zone = this.getTriggerZone(detection, rule);
 
+    // detectionLabel: use the raw detection label when present, fall back to
+    // the class-name text (e.g. "Animal") so ${detectionLabel} always has a value.
+    const detectionLabel = label || subkeyText || "";
+
     return text
       .toString()
       .replaceAll("${time}", String(time ?? ""))
@@ -4813,6 +4817,8 @@ export default class AdvancedNotifierPlugin
       .replaceAll("${plate}", label ?? "")
       .replaceAll("${streamName}", label ?? "")
       .replaceAll("${label}", label ?? "")
+      .replaceAll("${detectionLabel}", detectionLabel)
+      .replaceAll("${objectLabel}", detectionLabel)
       .replaceAll("${zone}", zone ?? "")
       .replaceAll("${room}", roomName ?? "");
   }

--- a/src/testData.ts
+++ b/src/testData.ts
@@ -537,3 +537,41 @@ export const animalData = {
         }
     }
 };
+
+/**
+ * Fixture: bird classifier detection with a species label.
+ *
+ * Expected template rendering (no test runner required — this documents intent):
+ *   template "${detectionLabel} detected"  →  "Northern Cardinal detected"
+ *   template "${objectLabel} detected"     →  "Northern Cardinal detected"
+ *   template "${label} detected"           →  "Northern Cardinal detected"
+ *   template "${classnameText} detected"   →  "Animal (Northern Cardinal) detected"
+ *                                             (using default animalWithLabelText)
+ *
+ * When detection.label is undefined (same camera, no label):
+ *   template "${detectionLabel} detected"  →  "Animal detected"  (falls back to subkeyText)
+ *   template "${label} detected"           →  " detected"        (empty string)
+ */
+export const birdDetectionFixture = {
+    detection: {
+        className: "animal",
+        score: 0.5793830752372742,
+        id: "h",
+        history: { firstSeen: 1777133351630, lastSeen: 1777133360160 },
+        clipped: true,
+        movement: { firstSeen: 1777133351693, lastSeen: 1777133360160, moving: true },
+        label: "Northern Cardinal",
+        zones: [],
+    },
+    expectedValues: {
+        detectionLabel: "Northern Cardinal",
+        objectLabel: "Northern Cardinal",
+        label: "Northern Cardinal",
+    },
+    fallbackExpectedValues: {
+        // When label is absent (detection.label = undefined)
+        detectionLabel: "Animal",  // falls back to animalText subkeyText
+        objectLabel: "Animal",
+        label: "",                 // ${label} yields empty string
+    },
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1168,7 +1168,7 @@ export const getTextSettings = (props: {
       title: "Object detection",
       type: "string",
       description:
-        "Expression used to render the text when an object detection happens. Available arguments ${classnameText} ${room} ${time} ${nvrLink}",
+        "Expression used to render the text when an object detection happens. Available arguments ${classnameText} ${classname} ${detectionLabel} ${objectLabel} ${label} ${room} ${zone} ${time} ${nvrLink}",
       defaultValue: !forMixin
         ? "${classnameText} detected in ${room}"
         : undefined,
@@ -3038,7 +3038,7 @@ export const getRuleSettings = async (props: {
         title: isDetectionRule ? "Custom text" : "Notification text",
         description: isAudioRule
           ? "Available arguments ${duration} ${decibels}"
-          : "Available arguments ${room} ${time} ${nvrLink} ${zone} ${classname} ${label}",
+          : "Available arguments ${room} ${time} ${nvrLink} ${zone} ${classname} ${classnameText} ${label} ${detectionLabel} ${objectLabel}",
         group,
         subgroup,
         type: "string",


### PR DESCRIPTION
Exposes ${detectionLabel} and ${objectLabel} in notification templates, mapping to detection.label (e.g. "Northern Cardinal") when present and falling back to the class-name text (e.g. "Animal") when absent.

While wiring these up, found several already-supported placeholders that were missing from the settings help text. Updated the object-detection and custom-rule message descriptions to list all available variables (${classname}, ${classnameText}, ${label}, ${zone}) alongside the new ${detectionLabel}/${objectLabel}.